### PR TITLE
ETL is not updated in Arduino's Library Manager

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=Embedded Template Library - Arduino
+name=Embedded Template Library ETL
 version=20.38.2
 author= John Wellbelove <john.wellbelove@etlcpp.com>
 maintainer=John Wellbelove <john.wellbelove@etlcpp.com>


### PR DESCRIPTION
I noticed that in Arduino's Library Manager the latest version is `20.22.0`, and I needed a feature from a newer version

after some search, I found out Arduino has an [Indexation log](https://github.com/arduino/library-registry/blob/main/FAQ.md#can-i-check-on-library-releases-being-added-to-library-manager)
and that `etl-arduino` as been failing [ever since 20.23.0](https://downloads.arduino.cc/libraries/logs/github.com/ETLCPP/etl-arduino/) with the log "Arduino:<version> has wrong library name, should be Embedded Template Library ETL"

so I fixed it

if you want to change the name, it probably need to be changed in [Arduino's library registry](https://github.com/arduino/library-registry/blob/main/repositories.txt)